### PR TITLE
chore: makes traceable blocking optional using a build tag.

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -125,3 +125,50 @@ jobs:
           build-args: |
             TRACEABLE_GOAGENT_DISTRO_VERSION=${{ matrix.distro_version }}
           tags: traceable_goagent_test:${{ matrix.distro_version }}
+
+  test-linux-distro-no-lib:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        distro_version:
+          - ubuntu_20.04
+    steps:
+      # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
+      - name: Check out code
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      # Since we can't pass non scalar matrix values we pass two values concatenated
+      # and do some parsing to get them separatedly.
+      - uses: rishabhgupta/split-by@v1
+        id: split
+        with:
+          string: ${{ matrix.distro_version }}
+          split-by: "_"
+
+      - id: string
+        uses: ASzc/change-string-case-action@v1
+        with:
+          string: ${{ steps.split.outputs._0}}
+
+      - name: Build test images
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          context: ./filter/traceable/cmd/libtraceable-downloader
+          file: ./filter/traceable/cmd/libtraceable-downloader/Dockerfile.${{ steps.split.outputs._0}}.test
+          build-args: |
+            ${{ steps.string.outputs.uppercase }}_VERSION=${{ steps.split.outputs._1}}
+            GO_VERSION=1.16.8
+          tags: traceable_goagent_test_base:${{ matrix.distro_version }}
+
+      - name: Run linux tests
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          context: .
+          file: ./_tests/Dockerfile.no_lib.test
+          build-args: |
+            TRACEABLE_GOAGENT_DISTRO_VERSION=${{ matrix.distro_version }}
+          tags: traceable_goagent_no_lib_test:${{ matrix.distro_version }}

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@ build-test-linux:
 	--build-arg TRACEABLE_GOAGENT_DISTRO_VERSION=$(TRACEABLE_GOAGENT_DISTRO_VERSION) \
 	-t traceable_goagent_test:$(TRACEABLE_GOAGENT_DISTRO_VERSION) .
 
+build-test-linux-no-lib:
+	@$(MAKE) -C ./filter/traceable/cmd/libtraceable-downloader build-install-image \
+	TRACEABLE_GOAGENT_DISTRO_VERSION=$(TRACEABLE_GOAGENT_DISTRO_VERSION)
+	@docker build -f ./_tests/Dockerfile.no_lib.test \
+	--progress plain \
+	--build-arg TRACEABLE_GOAGENT_DISTRO_VERSION=$(TRACEABLE_GOAGENT_DISTRO_VERSION) \
+	-t traceable_goagent_no_lib_test:$(TRACEABLE_GOAGENT_DISTRO_VERSION) .
+
 .PHONY: test-linux
 test-linux:
 	$(MAKE) build-test-linux TRACEABLE_GOAGENT_DISTRO_VERSION=debian_10
@@ -25,6 +33,7 @@ test-linux:
 	$(MAKE) build-test-linux TRACEABLE_GOAGENT_DISTRO_VERSION=amazonlinux_2
 	$(MAKE) build-test-linux TRACEABLE_GOAGENT_DISTRO_VERSION=ubuntu_18.04
 	$(MAKE) build-test-linux TRACEABLE_GOAGENT_DISTRO_VERSION=ubuntu_20.04
+	$(MAKE) build-test-linux-no-lib TRACEABLE_GOAGENT_DISTRO_VERSION=ubuntu_20.04
 
 .PHONY: bench
 bench:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,17 @@ Config values can be declared in config file, env variables or code. For further
 
 ### Traceable filter
 
-By default, `goagent` includes the [Traceable filter](./filter/traceable) into server instrumentations (e.g. http server or grpc server) based on the [configuration features](https://github.com/Traceableai/agent-config/blob/main/proto/ai/traceable/agent/config/v1/config.proto#L29). To run Traceable filter we need to download the library next to the application binary:
+By default, `goagent` includes the [Traceable filter](./filter/traceable) into server instrumentation (e.g. HTTP server or GRPC server)
+based on the [configuration features](https://github.com/Traceableai/agent-config/blob/main/proto/ai/traceable/agent/config/v1/config.proto#L29).
+To run Traceable filter we need to:
+
+Fist compile the binary using the build tag `traceable_blocking`, for example:
+
+```bash
+go build -tags 'traceable_blocking' -o myapp
+```
+
+Then, we need to download the library next to the application binary:
 
 ```bash
 # Install libtraceable downloader (run this from a non go.mod folder)
@@ -35,7 +45,7 @@ go install github.com/Traceableai/goagent/filter/traceable/cmd/libtraceable-down
 
 ...
 
-# Pull library in the binary dir
+# Pull library in the binary directory
 cd /path/to/myapp &&
 libtraceable-downloader pull-library
 ```

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ By default, `goagent` includes the [Traceable filter](./filter/traceable) into s
 based on the [configuration features](https://github.com/Traceableai/agent-config/blob/main/proto/ai/traceable/agent/config/v1/config.proto#L29).
 To run Traceable filter we need to:
 
-Fist compile the binary using the build tag `traceable_blocking`, for example:
+Fist compile the binary using the build tag `traceable_filter`, for example:
 
 ```bash
-go build -tags 'traceable_blocking' -o myapp
+go build -tags 'traceable_filter' -o myapp
 ```
 
 Then, we need to download the library next to the application binary:

--- a/_tests/Dockerfile.no_lib.test
+++ b/_tests/Dockerfile.no_lib.test
@@ -9,23 +9,16 @@ WORKDIR ${GOPATH}/src/github.com/Traceableai/goagent
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-# Go get expects the library to be present when retrieving the dependencies
-RUN cp /usr/local/traceable/libtraceable.so .
 RUN go get ./...
 
 COPY . .
 
 # Runs blocking package tests to make sure it works.
-RUN CGO_ENABLED=1 go test --tags=traceable_blocking -c ./filter/traceable
+RUN go test -c ./filter/traceable
 RUN ./traceable.test -test.v
-
-# Runs traceablefilter internal package tests to make sure it works.
-RUN CGO_ENABLED=1 go test -c ./instrumentation/internal/traceablefilter
-RUN ./traceablefilter.test -test.v
 
 WORKDIR ${GOPATH}/src/github.com/Traceableai/goagent/_tests
 
 # Runs the test app to make sure blocking filter works as expected.
-RUN cp /usr/local/traceable/libtraceable.so .
-RUN CGO_ENABLED=1 go build -o test-app .
+RUN go build -o test-app .
 RUN TA_LOG_LEVEL="debug" ./test-app

--- a/_tests/Dockerfile.test
+++ b/_tests/Dockerfile.test
@@ -16,10 +16,10 @@ RUN go get ./...
 COPY . .
 
 # Runs blocking package tests to make sure it works.
-RUN CGO_ENABLED=1 go test -c ./filter/traceable
+RUN CGO_ENABLED=1 go test --tags=traceable_blocking -c ./filter/traceable
 RUN ./traceable.test -test.v
 
-RUN CGO_ENABLED=1 go test -c ./instrumentation/internal/traceablefilter
+RUN CGO_ENABLED=1 go test --tags=traceable_blocking -c ./instrumentation/internal/traceablefilter
 RUN ./traceablefilter.test -test.v
 
 WORKDIR ${GOPATH}/src/github.com/Traceableai/goagent/_tests

--- a/_tests/Dockerfile.test
+++ b/_tests/Dockerfile.test
@@ -16,7 +16,7 @@ RUN go get ./...
 COPY . .
 
 # Runs blocking package tests to make sure it works.
-RUN CGO_ENABLED=1 go test --tags=traceable_blocking -c ./filter/traceable
+RUN CGO_ENABLED=1 go test --tags=traceable_filter -c ./filter/traceable
 RUN ./traceable.test -test.v
 
 # Runs traceablefilter internal package tests to make sure it works.

--- a/filter/traceable/filter.go
+++ b/filter/traceable/filter.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux && traceable_blocking
+// +build linux,traceable_blocking
 
 package traceable // import "github.com/Traceableai/goagent/filter/traceable"
 

--- a/filter/traceable/filter.go
+++ b/filter/traceable/filter.go
@@ -1,5 +1,5 @@
-//go:build linux && traceable_blocking
-// +build linux,traceable_blocking
+//go:build linux && traceable_filter
+// +build linux,traceable_filter
 
 package traceable // import "github.com/Traceableai/goagent/filter/traceable"
 

--- a/filter/traceable/filter_stub.go
+++ b/filter/traceable/filter_stub.go
@@ -1,5 +1,5 @@
-//go:build !linux || !traceable_blocking
-// +build !linux !traceable_blocking
+//go:build !linux || !traceable_filter
+// +build !linux !traceable_filter
 
 package traceable // import "github.com/Traceableai/goagent/filter/traceable"
 

--- a/filter/traceable/filter_stub.go
+++ b/filter/traceable/filter_stub.go
@@ -1,5 +1,5 @@
-//go:build !linux
-// +build !linux
+//go:build !linux || !traceable_blocking
+// +build !linux !traceable_blocking
 
 package traceable // import "github.com/Traceableai/goagent/filter/traceable"
 

--- a/filter/traceable/filter_stub_test.go
+++ b/filter/traceable/filter_stub_test.go
@@ -1,5 +1,5 @@
-//go:build !linux || !traceable_blocking
-// +build !linux !traceable_blocking
+//go:build !linux || !traceable_filter
+// +build !linux !traceable_filter
 
 package traceable
 

--- a/filter/traceable/filter_stub_test.go
+++ b/filter/traceable/filter_stub_test.go
@@ -1,5 +1,5 @@
-//go:build !linux
-// +build !linux
+//go:build !linux || !traceable_blocking
+// +build !linux !traceable_blocking
 
 package traceable
 

--- a/filter/traceable/filter_test.go
+++ b/filter/traceable/filter_test.go
@@ -1,5 +1,5 @@
-//go:build linux && traceable_blocking
-// +build linux,traceable_blocking
+//go:build linux && traceable_filter
+// +build linux,traceable_filter
 
 package traceable
 

--- a/filter/traceable/filter_test.go
+++ b/filter/traceable/filter_test.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux && traceable_blocking
+// +build linux,traceable_blocking
 
 package traceable
 

--- a/internal/state/closer.go
+++ b/internal/state/closer.go
@@ -26,3 +26,9 @@ func CloserFn() Closer {
 		}
 	}
 }
+
+func reset() {
+	closerMux.Lock()
+	closers = nil
+	closerMux.Unlock()
+}

--- a/internal/state/closer_test.go
+++ b/internal/state/closer_test.go
@@ -1,0 +1,42 @@
+package state
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppendCloser(t *testing.T) {
+	f1Called := false
+	f1 := func() { f1Called = true }
+	AppendCloser(f1)
+
+	f2Called := false
+	f2 := func() { f2Called = true }
+	AppendCloser(f2)
+
+	CloserFn()()
+	assert.True(t, f1Called)
+	assert.True(t, f2Called)
+}
+
+func TestAppendCloserConcurrently(t *testing.T) {
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		AppendCloser(func() {})
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		AppendCloser(func() {})
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	assert.Len(t, closers, 2)
+}

--- a/internal/state/closer_test.go
+++ b/internal/state/closer_test.go
@@ -19,6 +19,8 @@ func TestAppendCloser(t *testing.T) {
 	CloserFn()()
 	assert.True(t, f1Called)
 	assert.True(t, f2Called)
+
+	reset()
 }
 
 func TestAppendCloserConcurrently(t *testing.T) {
@@ -39,4 +41,6 @@ func TestAppendCloserConcurrently(t *testing.T) {
 	wg.Wait()
 
 	assert.Len(t, closers, 2)
+
+	reset()
 }


### PR DESCRIPTION
This PR makes it possible to enable/disable the logic of traceable filter by using a build tag. This is useful to not to carry the complexity of using the traceable filter it it isn't needed.