### PR TITLE
chore: adds load env for config.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,18 @@ type AgentConfig struct {
 	Blocking *traceableconfig.AgentConfig
 }
 
+func LoadEnv(cfg *AgentConfig) {
+	cfg.Tracing.LoadFromEnv(
+		hyperconfig.WithEnvPrefix(envPrefix),
+		hyperconfig.WithDefaults(defaultConfig.Tracing),
+	)
+
+	cfg.Blocking.LoadFromEnv(
+		traceableconfig.WithEnvPrefix(envPrefix),
+		traceableconfig.WithDefaults(defaultConfig.Blocking),
+	)
+}
+
 func PropagationFormats(formats ...hyperconfig.PropagationFormat) []hyperconfig.PropagationFormat {
 	return formats
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"testing"
+
+	traceableconfig "github.com/Traceableai/agent-config/gen/go/v1"
+	hyperconfig "github.com/hypertrace/agent-config/gen/go/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigLoadIsNotOverridenByDefaults(t *testing.T) {
+	cfg := &AgentConfig{
+		Tracing: &hyperconfig.AgentConfig{
+			DataCapture: &hyperconfig.DataCapture{
+				RpcMetadata: &hyperconfig.Message{
+					Request: hyperconfig.Bool(false),
+				},
+			},
+		},
+		Blocking: &traceableconfig.AgentConfig{
+			Opa: &traceableconfig.Opa{
+				Enabled: traceableconfig.Bool(false),
+			},
+		},
+	}
+
+	assert.Equal(t, false, cfg.Tracing.DataCapture.RpcMetadata.Request.Value)
+	assert.Equal(t, false, cfg.Blocking.Opa.Enabled.Value)
+
+	LoadEnv(cfg)
+	// we verify here the value isn't overridden by default value (true)
+	assert.Equal(t, false, cfg.Tracing.DataCapture.RpcMetadata.Request.Value)
+	// we verify default value is used for undefined value (true)
+	assert.Equal(t, false, cfg.Blocking.Opa.Enabled.Value)
+}


### PR DESCRIPTION
This PR adds a missing function `loadEnv` to have feature parity with hypertrace/goagent.